### PR TITLE
Strip receiver address before sending tx

### DIFF
--- a/src/js/create_account_tx.js
+++ b/src/js/create_account_tx.js
@@ -20,7 +20,7 @@
     div.appendChild(document.createElement("br"));
     var ca_fee = 152050;
     function create_account() {
-        var to = create_address.value;
+        var to = create_address.value.trim();
         var amount = Math.floor(parseFloat(create_amount.value, 10) * token_units());
         var from = keys.pub();
         console.log([amount, ca_fee, from, to]);
@@ -32,7 +32,7 @@
         console.log(tx);
         var amount = Math.floor(parseFloat(create_amount.value, 10) * token_units());
         var amount0 = tx[5];
-        var to = create_address.value;
+        var to = create_address.value.trim();
         var to0 = tx[4];
         var fee0 = tx[3];
         if (!(amount == amount0)) {

--- a/src/js/delete_account_tx.js
+++ b/src/js/delete_account_tx.js
@@ -14,7 +14,7 @@
     div.appendChild(document.createElement("br"));
     var ca_fee = 152050;
     function create_account() {
-        var to = create_address.value;
+        var to = create_address.value.trim();
         var from = keys.pub();
         variable_public_get(["delete_acc_tx", to, from, ca_fee],
                             function(x) { create_tokens2(x, to, from, ca_fee);}

--- a/src/js/format.js
+++ b/src/js/format.js
@@ -179,11 +179,10 @@ function tree_number_det_power(base, top, bottom, t) {
 }
 function parse_address(A) {
     //remove spaces or periods. " " "."
-    A2 = A.replace(/\ /g,'');
+    A2 = A.trim();
     A3 = A2.replace(/\./g,'');
-    A4 = A3.replace(/\n/g,'');
     //if it is the wrong length, make an error.
     //88
-    B = ((A4).length == 88);
-    if (B) { return A4; } else { return 0; };
+    B = ((A3).length == 88);
+    if (B) { return A3; } else { return 0; };
 }

--- a/src/js/lookup_account.js
+++ b/src/js/lookup_account.js
@@ -23,7 +23,7 @@ function lookup_account1() {
     document.body.appendChild(document.createElement("br"));
 
     function lookup_account_helper() {
-        var x = lookup_account_address.value;
+        var x = lookup_account_address.value.trim();
 	console.log("lookup account");
         variable_public_get(["account", x], lookup_account_helper2);
     }

--- a/src/js/spend_tx.js
+++ b/src/js/spend_tx.js
@@ -55,10 +55,10 @@ function spend_1() {
     var fee;
     function spend_tokens() {
         //spend_address = document.getElementById("spend_address");
-        var to0 = spend_address.value;
+        var to0 = spend_address.value.trim();
 	var to = parse_address(to0);
         var amount = Math.floor(parseFloat(spend_amount.value, 10) * token_units());
-	
+
 	if (to == 0) {
 	    error_msg.innerHTML = "Badly formatted address";
 	} else {
@@ -92,7 +92,7 @@ function spend_1() {
     function spend_tokens2(tx) {
         var amount = Math.floor(parseFloat(spend_amount.value, 10) * token_units());
         var amount0 = tx[5];
-        var to = spend_address.value;
+        var to = spend_address.value.trim();
         var to0 = tx[4];
         var fee0 = tx[3];
         if (!(amount == amount0)) {


### PR DESCRIPTION
It's possbile to copy&paste receiver pubkey with trailing `\n` which leads to error when the wallet thinks the node changed receiver address.

This PR adds `trim()` call to the pubkey receiver value to strip whitespace and line terminator characters.